### PR TITLE
Add dev script as alias for start command

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "start": "tsc && concurrently -k -r \"tsc --watch\" \"wds\"",
+    "dev": "tsc && concurrently -k -r \"tsc --watch\" \"wds\"",
     "build": "rimraf dist && tsc && node --max-old-space-size=4096 node_modules/rollup/dist/bin/rollup -c rollup.config.mjs",
     "start:build": "web-dev-server --root-dir dist --app-index index.html --open",
     "lint": "eslint \"**/*.{js,ts}\" --ignore-path .gitignore",


### PR DESCRIPTION
Added a "dev" script to package.json that mirrors the functionality of the "start" script. This provides a more conventional npm command name while maintaining the existing start command for compatibility.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/fiddle?branchName=zen-studio&projectId=ca4aac9833764a17b1fb3f56d33d2a8c)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ca4aac9833764a17b1fb3f56d33d2a8c</projectId>-->